### PR TITLE
fix #7 parser_class_name is deprecate since bison 3.3

### DIFF
--- a/def/def_parser.yy
+++ b/def/def_parser.yy
@@ -2,7 +2,7 @@
 %language "c++"
 %glr-parser
 %token-table
-%define "parser_class_name" {DEFParser}
+%define api.parser.class {DEFParser}
 
 %code requires {
 	namespace def {

--- a/lef/lef_parser.yy
+++ b/lef/lef_parser.yy
@@ -1,10 +1,10 @@
 %define api.prefix {lef}
-%error-verbose
+%define parse.error verbose
 %language "c++"
 %glr-parser
 %debug
 %token-table
-%define "parser_class_name" {LEFParser}
+%define api.parser.class {LEFParser}
 
 %code requires {
 	namespace lef {

--- a/magic/magic_parser.yy
+++ b/magic/magic_parser.yy
@@ -1,10 +1,10 @@
 %define api.prefix {magic}
-%error-verbose
+%define parse.error verbose
 %language "c++"
 %glr-parser
 %debug
 %token-table
-%define "parser_class_name" {MagicParser}
+%define api.parser.class {MagicParser}
 
 %code requires {
 	namespace magic {

--- a/schematics_reader/schematics_parser.yy
+++ b/schematics_reader/schematics_parser.yy
@@ -1,5 +1,5 @@
-%error-verbose
-%define "parser_class_name" {SchematicsParser}
+%define parse.error verbose
+%define api.parser.class {SchematicsParser}
 %define api.prefix {schematics}
 %language "c++"
 

--- a/symbol_reader/symbol_parser.yy
+++ b/symbol_reader/symbol_parser.yy
@@ -1,10 +1,10 @@
 %define api.prefix {symbol}
-%error-verbose
+%define parse.error verbose
 %language "c++"
 %glr-parser
 %debug
 %token-table
-%define "parser_class_name" {SymbolParser}
+%define api.parser.class {SymbolParser}
 
 %code requires {
 	namespace symbol {

--- a/tech_reader/tech_parser.yy
+++ b/tech_reader/tech_parser.yy
@@ -1,10 +1,10 @@
 %define api.prefix {tech}
-%error-verbose
+%define parse.error verbose
 %language "c++"
 %glr-parser
 %debug
 %token-table
-%define "parser_class_name" {TechParser}
+%define api.parser.class {TechParser}
 
 %code requires {
 	namespace tech {


### PR DESCRIPTION
`parser_class_name` is deprecated since bison 3.3. So the parser should be changed to use `api.parser` class instead. For more information, please visit [Bison's reference](https://www.gnu.org/software/bison/manual/html_node/_0025define-Summary.html).